### PR TITLE
issue/75 🐛 Fix : accessToken 재발급 버그 수정

### DIFF
--- a/src/main/java/briefing/exception/ErrorCode.java
+++ b/src/main/java/briefing/exception/ErrorCode.java
@@ -47,7 +47,7 @@ public enum ErrorCode {
 
     // member 관련 에러
 
-    MEMBER_NOT_FOUND(BAD_REQUEST, "MEMBER_400_1", "사용자가 없습니다"),
+    MEMBER_NOT_FOUND(BAD_REQUEST, "MEMBER_001", "사용자가 없습니다"),
     MEMBER_NOT_SAME(BAD_REQUEST, "MEMBER_002", "로그인 된 사용자와 대상 사용자가 일치하지 않습니다."),
 
     // member 에러

--- a/src/main/java/briefing/member/api/MemberApi.java
+++ b/src/main/java/briefing/member/api/MemberApi.java
@@ -67,7 +67,7 @@ public class MemberApi {
         RefreshToken refreshToken = redisService.reGenerateRefreshToken(request);
         Member parsedMember = memberCommandService.parseRefreshToken(refreshToken);
         String accessToken = tokenProvider.createAccessToken(parsedMember.getId(),parsedMember.getSocialType().toString(), parsedMember.getSocialId(), List.of(new SimpleGrantedAuthority(parsedMember.getRole().toString())));
-        return CommonResponse.onSuccess(MemberConverter.toReIssueTokenDTO(accessToken,refreshToken.getToken()));
+        return CommonResponse.onSuccess(MemberConverter.toReIssueTokenDTO(parsedMember.getId(), accessToken,refreshToken.getToken()));
     }
 
 

--- a/src/main/java/briefing/member/api/MemberApi.java
+++ b/src/main/java/briefing/member/api/MemberApi.java
@@ -15,6 +15,10 @@ import briefing.validation.annotation.CheckSameMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +36,9 @@ import java.util.UUID;
 @Validated
 @RequestMapping("/members")
 @RequiredArgsConstructor
+@ApiResponses({
+        @ApiResponse(responseCode = "COMMON000", description = "SERVER ERROR, 백앤드 개발자에게 알려주세요", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+})
 public class MemberApi {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
@@ -62,6 +69,13 @@ public class MemberApi {
         return CommonResponse.onSuccess(MemberConverter.toLoginDTO(member, accessToken, refreshToken));
     }
 
+    @Operation(summary = "02-01 Member\uD83D\uDC64 accessToken 재발급 받기", description = "accessToken 만료 시 refreshToken으로 재발급을 받는 API 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000",description = "OK, 성공"),
+            @ApiResponse(responseCode = "COMMON001", description = "request body에 담길 값이 이상함, result를 확인해주세요!",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH005", description = "리프레시 토큰도 만료, 다시 로그인",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH009", description = "리프레시 토큰 모양이 잘못 됨",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     @PostMapping("/auth/token")
     public CommonResponse<MemberResponse.ReIssueTokenDTO> reissueToken(@Valid @RequestBody MemberRequest.ReissueDTO request){
         RefreshToken refreshToken = redisService.reGenerateRefreshToken(request);
@@ -70,11 +84,19 @@ public class MemberApi {
         return CommonResponse.onSuccess(MemberConverter.toReIssueTokenDTO(parsedMember.getId(), accessToken,refreshToken.getToken()));
     }
 
-
+    @Operation(summary = "02-01 Member\uD83D\uDC64 회원 탈퇴", description = "회원 탈퇴 API 입니다.")
     @DeleteMapping("/{memberId}")
     @Parameters({
             @Parameter(name = "member", hidden = true),
             @Parameter(name = "memberId", description = "삭제 대상 멤버아이디")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000",description = "OK, 성공"),
+            @ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "MEMBER_001", description = "사용자가 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "MEMBER_002", description = "로그인 한 사용자와 탈퇴 대상이 동일하지 않습니다.",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     public CommonResponse<MemberResponse.QuitDTO> quitMember(@AuthMember Member member, @CheckSameMember @PathVariable Long memberId){
         memberCommandService.deleteMember(memberId);

--- a/src/main/java/briefing/member/api/MemberConverter.java
+++ b/src/main/java/briefing/member/api/MemberConverter.java
@@ -49,8 +49,9 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponse.ReIssueTokenDTO toReIssueTokenDTO(String accessToken, String refreshToken){
+    public static MemberResponse.ReIssueTokenDTO toReIssueTokenDTO(Long memberId,String accessToken, String refreshToken){
         return MemberResponse.ReIssueTokenDTO.builder()
+                .memberId(memberId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/briefing/member/application/dto/MemberResponse.java
+++ b/src/main/java/briefing/member/application/dto/MemberResponse.java
@@ -23,6 +23,7 @@ public class MemberResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ReIssueTokenDTO{
+        private Long memberId;
         private String accessToken;
         private String refreshToken;
     }

--- a/src/main/java/briefing/redis/domain/RefreshToken.java
+++ b/src/main/java/briefing/redis/domain/RefreshToken.java
@@ -14,9 +14,9 @@ import java.time.LocalDateTime;
 public class RefreshToken {
 
     @Id
-    private Long memberId;
-
     private String token;
+
+    private Long memberId;
 
     private LocalDateTime expireTime;
 }

--- a/src/main/java/briefing/redis/repository/RefreshTokenRepository.java
+++ b/src/main/java/briefing/redis/repository/RefreshTokenRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 
-    Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/briefing/redis/service/RedisServiceImpl.java
+++ b/src/main/java/briefing/redis/service/RedisServiceImpl.java
@@ -57,7 +57,7 @@ public class RedisServiceImpl implements RedisService{
     public RefreshToken reGenerateRefreshToken(MemberRequest.ReissueDTO request) {
         if(request.getRefreshToken() == null)
             throw new MemberException(ErrorCode.INVALID_TOKEN_EXCEPTION);
-        RefreshToken findRefreshToken = refreshTokenRepository.findById(request.getRefreshToken()).orElseThrow(() -> new RefreshTokenException(ErrorCode.INVALID_TOKEN_EXCEPTION));
+        RefreshToken findRefreshToken = refreshTokenRepository.findById(request.getRefreshToken()).orElseThrow(() -> new RefreshTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
         LocalDateTime expireTime = findRefreshToken.getExpireTime();
         LocalDateTime current = LocalDateTime.now();
         // 테스트용, 실제로는 현재 시간 + accessToken 만료 시간

--- a/src/main/java/briefing/redis/service/RedisServiceImpl.java
+++ b/src/main/java/briefing/redis/service/RedisServiceImpl.java
@@ -57,7 +57,7 @@ public class RedisServiceImpl implements RedisService{
     public RefreshToken reGenerateRefreshToken(MemberRequest.ReissueDTO request) {
         if(request.getRefreshToken() == null)
             throw new MemberException(ErrorCode.INVALID_TOKEN_EXCEPTION);
-        RefreshToken findRefreshToken = refreshTokenRepository.findByToken(request.getRefreshToken()).orElseThrow(() -> new RefreshTokenException(ErrorCode.INVALID_TOKEN_EXCEPTION));
+        RefreshToken findRefreshToken = refreshTokenRepository.findById(request.getRefreshToken()).orElseThrow(() -> new RefreshTokenException(ErrorCode.INVALID_TOKEN_EXCEPTION));
         LocalDateTime expireTime = findRefreshToken.getExpireTime();
         LocalDateTime current = LocalDateTime.now();
         // 테스트용, 실제로는 현재 시간 + accessToken 만료 시간
@@ -84,8 +84,7 @@ public class RedisServiceImpl implements RedisService{
 
     @Override
     public void deleteRefreshToken(String refreshToken) {
-        Optional<RefreshToken> target = refreshTokenRepository.findByToken(refreshToken);
-        if(target.isPresent())
-            refreshTokenRepository.delete(target.get());
+        Optional<RefreshToken> target = refreshTokenRepository.findById(refreshToken);
+        target.ifPresent(refreshTokenRepository::delete);
     }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->

issue/75, accessToken 재발급 안되는 버그 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- redis의 RefreshToken의 id를 토큰으로 변경
- 그에 따른 redisService의 함수들의 변경
- 응답 시 멤버 아이디를 포함하기 위한 변경

## ⏳ 작업 내용
- [ ] accessToken 재발급 안되는 버그 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

