### PR TITLE
Feature/90 : 브리핑 목록 조회 v2 수정사항

### DIFF
--- a/src/main/java/briefing/briefing/api/BriefingConverter.java
+++ b/src/main/java/briefing/briefing/api/BriefingConverter.java
@@ -7,6 +7,7 @@ import briefing.briefing.domain.Briefing;
 import briefing.briefing.domain.BriefingType;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,12 +24,22 @@ public class BriefingConverter {
                 .build();
     }
 
+    private static LocalDateTime getPreviewListDTOCreatedAt(final LocalDate date, List<Briefing> briefingList) {
+        if(!briefingList.isEmpty()) {
+            return briefingList.get(0).getCreatedAt();
+        }
+        if(date != null) {
+            return date.atTime(3,0);
+        }
+        return LocalDateTime.now();
+    }
+
     public static BriefingResponseDTO.BriefingPreviewListDTO toBriefingPreviewListDTO(final LocalDate date, List<Briefing> briefingList){
         final List<BriefingResponseDTO.BriefingPreviewDTO> briefingPreviewDTOList = briefingList.stream()
                 .map(BriefingConverter::toBriefingPreviewDTO).toList();
 
         return BriefingResponseDTO.BriefingPreviewListDTO.builder()
-                .createdAt(date.atTime(3,0))
+                .createdAt(getPreviewListDTOCreatedAt(date, briefingList))
                 .briefings(briefingPreviewDTOList)
                 .build();
     }

--- a/src/main/java/briefing/briefing/application/BriefingQueryService.java
+++ b/src/main/java/briefing/briefing/application/BriefingQueryService.java
@@ -22,8 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BriefingQueryService {
 
-  private final BriefingRepository briefingRepository;
-
   public List<Briefing> findBriefings(BriefingRequestParam.BriefingPreviewListParam params, APIVersion version) {
     BriefingQueryContext briefingQueryContext = BriefingQueryContextFactory.getContextByVersion(version);
     return briefingQueryContext.findBriefings(params);

--- a/src/main/java/briefing/briefing/application/dto/BriefingRequestParam.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingRequestParam.java
@@ -16,8 +16,11 @@ public class BriefingRequestParam {
     public static class BriefingPreviewListParam {
         @NotNull
         private BriefingType type;
-        @NotNull
         private LocalDate date;
         private TimeOfDay timeOfDay = TimeOfDay.MORNING;
+
+        public boolean isPresentDate() {
+            return date != null;
+        }
     }
 }

--- a/src/main/java/briefing/briefing/application/strategy/BriefingV2QueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingV2QueryStrategy.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,11 +18,17 @@ public class BriefingV2QueryStrategy implements BriefingQueryStrategy{
 
     @Override
     public List<Briefing> findBriefings(BriefingRequestParam.BriefingPreviewListParam params) {
-        final LocalDateTime startDateTime = params.getDate().atStartOfDay();
-        final LocalDateTime endDateTime = params.getDate().atTime(LocalTime.MAX);
+        if(params.isPresentDate()) {
+            final LocalDateTime startDateTime = params.getDate().atStartOfDay();
+            final LocalDateTime endDateTime = params.getDate().atTime(LocalTime.MAX);
 
-        return briefingRepository.findBriefingsWithScrapCount(
-                params.getType(), startDateTime, endDateTime, params.getTimeOfDay());
+            return briefingRepository.findBriefingsWithScrapCount(
+                    params.getType(), startDateTime, endDateTime, params.getTimeOfDay());
+        }
+
+        List<Briefing> briefingList = briefingRepository.findTop10ByTypeOrderByCreatedAtDesc(params.getType());
+        Collections.reverse(briefingList);
+        return briefingList;
     }
 
     @Override

--- a/src/main/java/briefing/briefing/domain/BriefingType.java
+++ b/src/main/java/briefing/briefing/domain/BriefingType.java
@@ -14,8 +14,7 @@ public enum BriefingType {
   GLOBAL("Global"),
   SOCIAL("Social"),
   SCIENCE("Science"),
-  ECONOMY("Economy"),
-  CULTURE("Culture");
+  ECONOMY("Economy");
 
   private final String value;
 

--- a/src/main/java/briefing/briefing/domain/repository/BriefingCustomRepository.java
+++ b/src/main/java/briefing/briefing/domain/repository/BriefingCustomRepository.java
@@ -11,5 +11,7 @@ import java.util.Optional;
 public interface BriefingCustomRepository {
     List<Briefing> findBriefingsWithScrapCount(BriefingType type, LocalDateTime start, LocalDateTime end, TimeOfDay timeOfDay);
 
+    List<Briefing> findTop10ByTypeOrderByCreatedAtDesc(BriefingType type);
+
     Optional<Briefing> findByIdWithScrapCount(Long id);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,8 +27,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-        #        show_sql: true
-        #        format_sql: true
+        show_sql: true
+        format_sql: true
         use_sql_comments: true
         hbm2ddl:
           auto: update


### PR DESCRIPTION
# 🚀 개요
브리핑 목록 조회에서 날짜와 시간 쿼리 스트링 없이 분야만 포함했을 시, 최신 데이터를 내려줍니다.

## ⏳ 작업 내용
- [x] timeOfDay와 date 필수여부 false로 변경
- [x] CULTURE 타입 없애기
- [x] /v2/briefings?type=SOCIAL 처럼 요청시, 최신 10건 내려주기

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

