### PR TITLE
Feature/102 : API URI 버저닝 

### DIFF
--- a/src/main/java/briefing/briefing/api/BriefingApi.java
+++ b/src/main/java/briefing/briefing/api/BriefingApi.java
@@ -40,7 +40,6 @@ public class BriefingApi {
   public CommonResponse<BriefingResponseDTO.BriefingPreviewListDTOV2> findBriefingsV2(
           @ParameterObject @ModelAttribute BriefingRequestParam.BriefingPreviewListParam params
   ) {
-
     List<Briefing> briefingList = briefingQueryService.findBriefings(params, APIVersion.V2);
     return CommonResponse.onSuccess(BriefingConverter.toBriefingPreviewListDTOV2(params.getDate(), briefingList));
   }

--- a/src/main/java/briefing/briefing/api/BriefingApi.java
+++ b/src/main/java/briefing/briefing/api/BriefingApi.java
@@ -71,7 +71,7 @@ public class BriefingApi {
   @GetMapping("/v2/briefings/{id}")
   @Operation(summary = "03-02Briefing \uD83D\uDCF0  브리핑 단건 조회 V2", description = "")
   @Parameter(name = "member", hidden = true)
-  public CommonResponse<BriefingResponseDTO.BriefingDetailDTO> findBriefingV2(
+  public CommonResponse<BriefingResponseDTO.BriefingDetailDTOV2> findBriefingV2(
           @PathVariable final Long id,
           @AuthMember Member member
   ) {
@@ -83,7 +83,7 @@ public class BriefingApi {
     Boolean isBriefingOpen = false;
     Boolean isWarning = false;
 
-    return CommonResponse.onSuccess(BriefingConverter.toBriefingDetailDTO(briefingQueryService.findBriefing(id, APIVersion.V2), isScrap, isBriefingOpen, isWarning));
+    return CommonResponse.onSuccess(BriefingConverter.toBriefingDetailDTOV2(briefingQueryService.findBriefing(id, APIVersion.V2), isScrap, isBriefingOpen, isWarning));
   }
 
   @GetMapping("/briefings/{id}")

--- a/src/main/java/briefing/briefing/api/BriefingApi.java
+++ b/src/main/java/briefing/briefing/api/BriefingApi.java
@@ -10,19 +10,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import briefing.briefing.domain.TimeOfDay;
 import briefing.common.enums.APIVersion;
 import briefing.common.response.CommonResponse;
 import briefing.member.domain.Member;
 import briefing.scrap.application.ScrapQueryService;
 import briefing.security.handler.annotation.AuthMember;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
+
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
@@ -39,12 +37,12 @@ public class BriefingApi {
 
   @GetMapping("/v2/briefings")
   @Operation(summary = "03-01Briefing \uD83D\uDCF0  브리핑 목록 조회 V2", description = "")
-  public CommonResponse<BriefingResponseDTO.BriefingPreviewListDTO> findBriefingsV2(
+  public CommonResponse<BriefingResponseDTO.BriefingPreviewListDTOV2> findBriefingsV2(
           @ParameterObject @ModelAttribute BriefingRequestParam.BriefingPreviewListParam params
   ) {
 
     List<Briefing> briefingList = briefingQueryService.findBriefings(params, APIVersion.V2);
-    return CommonResponse.onSuccess(BriefingConverter.toBriefingPreviewListDTO(params.getDate(), briefingList));
+    return CommonResponse.onSuccess(BriefingConverter.toBriefingPreviewListDTOV2(params.getDate(), briefingList));
   }
 
   @GetMapping("/briefings")

--- a/src/main/java/briefing/briefing/api/BriefingConverter.java
+++ b/src/main/java/briefing/briefing/api/BriefingConverter.java
@@ -93,6 +93,30 @@ public class BriefingConverter {
                 .isScrap(isScrap)
                 .isBriefingOpen(isBriefingOpen)
                 .isWarning(isWarning)
+                .build();
+    }
+
+    public static BriefingResponseDTO.BriefingDetailDTOV2 toBriefingDetailDTOV2(
+            Briefing briefing,
+            Boolean isScrap,
+            Boolean isBriefingOpen,
+            Boolean isWarning
+    ){
+
+        List<BriefingResponseDTO.ArticleResponseDTO> articleResponseDTOList = briefing.getBriefingArticles().stream()
+                .map(article -> toArticleResponseDTO(article.getArticle())).toList();
+
+        return BriefingResponseDTO.BriefingDetailDTOV2.builder()
+                .id(briefing.getId())
+                .ranks(briefing.getRanks())
+                .title(briefing.getTitle())
+                .subtitle(briefing.getSubtitle())
+                .content(briefing.getContent())
+                .date(briefing.getCreatedAt().toLocalDate())
+                .articles(articleResponseDTOList)
+                .isScrap(isScrap)
+                .isBriefingOpen(isBriefingOpen)
+                .isWarning(isWarning)
                 .scrapCount(briefing.getScrapCount())
                 .gptModel(briefing.getGptModel())
                 .timeOfDay(briefing.getTimeOfDay())

--- a/src/main/java/briefing/briefing/api/BriefingConverter.java
+++ b/src/main/java/briefing/briefing/api/BriefingConverter.java
@@ -14,13 +14,22 @@ import java.util.stream.Collectors;
 
 public class BriefingConverter {
 
+    public static BriefingResponseDTO.BriefingPreviewDTOV2 toBriefingPreviewDTOV2(Briefing briefing){
+        return BriefingResponseDTO.BriefingPreviewDTOV2.builder()
+                .id(briefing.getId())
+                .ranks(briefing.getRanks())
+                .title(briefing.getTitle())
+                .subtitle(briefing.getSubtitle())
+                .scrapCount(briefing.getScrapCount())
+                .build();
+    }
+
     public static BriefingResponseDTO.BriefingPreviewDTO toBriefingPreviewDTO(Briefing briefing){
         return BriefingResponseDTO.BriefingPreviewDTO.builder()
                 .id(briefing.getId())
                 .ranks(briefing.getRanks())
                 .title(briefing.getTitle())
                 .subtitle(briefing.getSubtitle())
-                .scrapCount(briefing.getScrapCount())
                 .build();
     }
 
@@ -32,6 +41,16 @@ public class BriefingConverter {
             return date.atTime(3,0);
         }
         return LocalDateTime.now();
+    }
+
+    public static BriefingResponseDTO.BriefingPreviewListDTOV2 toBriefingPreviewListDTOV2(final LocalDate date, List<Briefing> briefingList){
+        final List<BriefingResponseDTO.BriefingPreviewDTOV2> briefingPreviewDTOList = briefingList.stream()
+                .map(BriefingConverter::toBriefingPreviewDTOV2).toList();
+
+        return BriefingResponseDTO.BriefingPreviewListDTOV2.builder()
+                .createdAt(getPreviewListDTOCreatedAt(date, briefingList))
+                .briefings(briefingPreviewDTOList)
+                .build();
     }
 
     public static BriefingResponseDTO.BriefingPreviewListDTO toBriefingPreviewListDTO(final LocalDate date, List<Briefing> briefingList){

--- a/src/main/java/briefing/briefing/application/dto/BriefingRequestParam.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingRequestParam.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BriefingRequestParam {
 
+    @Builder
     @Getter @Setter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/briefing/briefing/application/dto/BriefingResponseDTO.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingResponseDTO.java
@@ -64,6 +64,23 @@ public class BriefingResponseDTO {
         Boolean isScrap;
         Boolean isBriefingOpen;
         Boolean isWarning;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BriefingDetailDTOV2{
+        Long id;
+        Integer ranks;
+        String title;
+        String subtitle;
+        String content;
+        LocalDate date;
+        List<ArticleResponseDTO> articles;
+        Boolean isScrap;
+        Boolean isBriefingOpen;
+        Boolean isWarning;
         @Builder.Default
         Integer scrapCount = 0;
         @Builder.Default

--- a/src/main/java/briefing/briefing/application/dto/BriefingResponseDTO.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingResponseDTO.java
@@ -29,13 +29,24 @@ public class BriefingResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class BriefingPreviewDTO{
+    public static class BriefingPreviewDTOV2{
         Long id;
         Integer ranks;
         String title;
         String subtitle;
         @Builder.Default
         Integer scrapCount = 0;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BriefingPreviewDTO{
+        Long id;
+        Integer ranks;
+        String title;
+        String subtitle;
     }
 
     @Builder
@@ -61,6 +72,15 @@ public class BriefingResponseDTO {
         TimeOfDay timeOfDay = TimeOfDay.MORNING;
         @Builder.Default
         BriefingType type = BriefingType.KOREA;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BriefingPreviewListDTOV2{
+        LocalDateTime createdAt;
+        List<BriefingPreviewDTOV2> briefings;
     }
 
     @Builder

--- a/src/main/java/briefing/member/api/MemberApi.java
+++ b/src/main/java/briefing/member/api/MemberApi.java
@@ -33,7 +33,6 @@ import java.util.List;
 @Tag(name = "02-Member \uD83D\uDC64",description = "사용자 관련 API")
 @RestController
 @Validated
-@RequestMapping("/members")
 @RequiredArgsConstructor
 @ApiResponses({
         @ApiResponse(responseCode = "COMMON000", description = "SERVER ERROR, 백앤드 개발자에게 알려주세요", content = @Content(schema = @Schema(implementation = CommonResponse.class))),
@@ -47,7 +46,7 @@ public class MemberApi {
     private final RedisService redisService;
 
     @Operation(summary = "Member\uD83D\uDC64 토큰 잘 발급되나 테스트용API", description = "테스트 용")
-    @GetMapping("/auth/test")
+    @GetMapping("/members/auth/test")
     public CommonResponse<MemberResponse.LoginDTO> testGenerateToken(){
         Member member = memberQueryService.testForTokenApi();
         String accessToken = tokenProvider.createAccessToken(member.getId(), member.getSocialType().toString() ,member.getSocialId(), Arrays.asList(new SimpleGrantedAuthority(member.getRole().name())));
@@ -55,27 +54,38 @@ public class MemberApi {
         return CommonResponse.onSuccess(MemberConverter.toLoginDTO(member,accessToken, refreshToken.getToken()));
     }
 
-    @Operation(summary = "02-01 Member\uD83D\uDC64 소셜 로그인 #FRAME", description = "구글, 애플 소셜로그인 API입니다.")
-    @PostMapping("/auth/{socialType}")
+    @Operation(summary = "02-01 Member\uD83D\uDC64 소셜 로그인 V1", description = "구글, 애플 소셜로그인 API입니다.")
+    @PostMapping("/members/auth/{socialType}")
     public CommonResponse<MemberResponse.LoginDTO> login(
         @Parameter(description = "소셜로그인 종류", example = "google")  @PathVariable final SocialType socialType,
         @RequestBody final MemberRequest.LoginDTO request
     ) {
         Member member = memberCommandService.login(socialType, request);
-        // TODO - TokenProvider에서 발급해주도록 변경
         String accessToken = tokenProvider.createAccessToken(member.getId(),member.getSocialType().toString() ,member.getSocialId(), List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name())));
         String refreshToken = redisService.generateRefreshToken(member.getSocialId(),member.getSocialType()).getToken();
         return CommonResponse.onSuccess(MemberConverter.toLoginDTO(member, accessToken, refreshToken));
     }
 
-    @Operation(summary = "02-01 Member\uD83D\uDC64 accessToken 재발급 받기", description = "accessToken 만료 시 refreshToken으로 재발급을 받는 API 입니다.")
+    @Operation(summary = "02-01 Member\uD83D\uDC64 소셜 로그인 V2", description = "구글, 애플 소셜로그인 API입니다.")
+    @PostMapping("/v2/members/auth/{socialType}")
+    public CommonResponse<MemberResponse.LoginDTO> loginV2(
+            @Parameter(description = "소셜로그인 종류", example = "google")  @PathVariable final SocialType socialType,
+            @RequestBody final MemberRequest.LoginDTO request
+    ) {
+        Member member = memberCommandService.login(socialType, request);
+        String accessToken = tokenProvider.createAccessToken(member.getId(),member.getSocialType().toString() ,member.getSocialId(), List.of(new SimpleGrantedAuthority(MemberRole.ROLE_USER.name())));
+        String refreshToken = redisService.generateRefreshToken(member.getSocialId(),member.getSocialType()).getToken();
+        return CommonResponse.onSuccess(MemberConverter.toLoginDTO(member, accessToken, refreshToken));
+    }
+
+    @Operation(summary = "02-01 Member\uD83D\uDC64 accessToken 재발급 받기 V1", description = "accessToken 만료 시 refreshToken으로 재발급을 받는 API 입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "1000",description = "OK, 성공"),
             @ApiResponse(responseCode = "COMMON001", description = "request body에 담길 값이 이상함, result를 확인해주세요!",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "AUTH005", description = "리프레시 토큰도 만료, 다시 로그인",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
             @ApiResponse(responseCode = "AUTH009", description = "리프레시 토큰 모양이 잘못 됨",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
-    @PostMapping("/auth/token")
+    @PostMapping("/members/auth/token")
     public CommonResponse<MemberResponse.ReIssueTokenDTO> reissueToken(@Valid @RequestBody MemberRequest.ReissueDTO request){
         RefreshToken refreshToken = redisService.reGenerateRefreshToken(request);
         Member parsedMember = memberCommandService.parseRefreshToken(refreshToken);
@@ -83,8 +93,23 @@ public class MemberApi {
         return CommonResponse.onSuccess(MemberConverter.toReIssueTokenDTO(parsedMember.getId(), accessToken,refreshToken.getToken()));
     }
 
-    @Operation(summary = "02-01 Member\uD83D\uDC64 회원 탈퇴", description = "회원 탈퇴 API 입니다.")
-    @DeleteMapping("/{memberId}")
+    @Operation(summary = "02-01 Member\uD83D\uDC64 accessToken 재발급 받기 V2", description = "accessToken 만료 시 refreshToken으로 재발급을 받는 API 입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000",description = "OK, 성공"),
+            @ApiResponse(responseCode = "COMMON001", description = "request body에 담길 값이 이상함, result를 확인해주세요!",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH005", description = "리프레시 토큰도 만료, 다시 로그인",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH009", description = "리프레시 토큰 모양이 잘못 됨",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    @PostMapping("/v2/members/auth/token")
+    public CommonResponse<MemberResponse.ReIssueTokenDTO> reissueTokenV2(@Valid @RequestBody MemberRequest.ReissueDTO request){
+        RefreshToken refreshToken = redisService.reGenerateRefreshToken(request);
+        Member parsedMember = memberCommandService.parseRefreshToken(refreshToken);
+        String accessToken = tokenProvider.createAccessToken(parsedMember.getId(),parsedMember.getSocialType().toString(), parsedMember.getSocialId(), List.of(new SimpleGrantedAuthority(parsedMember.getRole().toString())));
+        return CommonResponse.onSuccess(MemberConverter.toReIssueTokenDTO(parsedMember.getId(), accessToken,refreshToken.getToken()));
+    }
+
+    @Operation(summary = "02-01 Member\uD83D\uDC64 회원 탈퇴 V1", description = "회원 탈퇴 API 입니다.")
+    @DeleteMapping("/members/{memberId}")
     @Parameters({
             @Parameter(name = "member", hidden = true),
             @Parameter(name = "memberId", description = "삭제 대상 멤버아이디")
@@ -98,6 +123,25 @@ public class MemberApi {
             @ApiResponse(responseCode = "MEMBER_002", description = "로그인 한 사용자와 탈퇴 대상이 동일하지 않습니다.",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
     })
     public CommonResponse<MemberResponse.QuitDTO> quitMember(@AuthMember Member member, @CheckSameMember @PathVariable Long memberId){
+        memberCommandService.deleteMember(memberId);
+        return CommonResponse.onSuccess(MemberConverter.toQuitDTO());
+    }
+
+    @Operation(summary = "02-01 Member\uD83D\uDC64 회원 탈퇴 V2", description = "회원 탈퇴 API 입니다.")
+    @DeleteMapping("/v2/members/{memberId}")
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+            @Parameter(name = "memberId", description = "삭제 대상 멤버아이디")
+    })
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000",description = "OK, 성공"),
+            @ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "MEMBER_001", description = "사용자가 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "MEMBER_002", description = "로그인 한 사용자와 탈퇴 대상이 동일하지 않습니다.",content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<MemberResponse.QuitDTO> quitMemberV2(@AuthMember Member member, @CheckSameMember @PathVariable Long memberId){
         memberCommandService.deleteMember(memberId);
         return CommonResponse.onSuccess(MemberConverter.toQuitDTO());
     }

--- a/src/main/java/briefing/scrap/api/ScrapApi.java
+++ b/src/main/java/briefing/scrap/api/ScrapApi.java
@@ -15,30 +15,51 @@ import java.util.List;
 
 @Tag(name = "05-Scrap 📁", description = "스크랩 관련 API")
 @RestController
-@RequestMapping("/scraps")
 @RequiredArgsConstructor
 public class ScrapApi {
     private final ScrapQueryService scrapQueryService;
     private final ScrapCommandService scrapCommandService;
 
-    @Operation(summary = "05-01 Scrap📁 스크랩하기 #FRAME", description = "브리핑을 스크랩하는 API입니다.")
-    @PostMapping("/briefings")
+    @Operation(summary = "05-01 Scrap📁 스크랩하기 V1", description = "브리핑을 스크랩하는 API입니다.")
+    @PostMapping("/scraps/briefings")
     public CommonResponse<ScrapResponse.CreateDTO> create(@RequestBody ScrapRequest.CreateDTO request) {
         Scrap createdScrap = scrapCommandService.create(request);
         return CommonResponse.onSuccess(ScrapConverter.toCreateDTO(createdScrap));
     }
 
-    @Operation(summary = "05-02 Scrap📁 스크랩 취소 #FRAME", description = "스크랩을 취소하는 API입니다.")
-    @DeleteMapping("/briefings/{briefingId}/members/{memberId}")
+    @Operation(summary = "05-01 Scrap📁 스크랩하기 V2", description = "브리핑을 스크랩하는 API입니다.")
+    @PostMapping("/v2/scraps/briefings")
+    public CommonResponse<ScrapResponse.CreateDTO> createV2(@RequestBody ScrapRequest.CreateDTO request) {
+        Scrap createdScrap = scrapCommandService.create(request);
+        return CommonResponse.onSuccess(ScrapConverter.toCreateDTO(createdScrap));
+    }
+
+    @Operation(summary = "05-02 Scrap📁 스크랩 취소 V1", description = "스크랩을 취소하는 API입니다.")
+    @DeleteMapping("/scraps/briefings/{briefingId}/members/{memberId}")
     public CommonResponse<ScrapResponse.DeleteDTO> delete(@PathVariable Long briefingId, @PathVariable Long memberId) {
         Scrap deletedScrap = scrapCommandService.delete(briefingId, memberId);
         return CommonResponse.onSuccess(ScrapConverter.toDeleteDTO(deletedScrap));
     }
 
-    @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 #FRAME", description = "내 스크랩을 조회하는 API입니다.")
-    @GetMapping("/briefings/members/{memberId}")
+    @Operation(summary = "05-02 Scrap📁 스크랩 취소 V2", description = "스크랩을 취소하는 API입니다.")
+    @DeleteMapping("/v2/scraps/briefings/{briefingId}/members/{memberId}")
+    public CommonResponse<ScrapResponse.DeleteDTO> deleteV2(@PathVariable Long briefingId, @PathVariable Long memberId) {
+        Scrap deletedScrap = scrapCommandService.delete(briefingId, memberId);
+        return CommonResponse.onSuccess(ScrapConverter.toDeleteDTO(deletedScrap));
+    }
+
+
+    @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 V1", description = "내 스크랩을 조회하는 API입니다.")
+    @GetMapping("/scraps/briefings/members/{memberId}")
     public CommonResponse<List<ScrapResponse.ReadDTO>> getScrapsByMember(@PathVariable Long memberId) {
         List<Scrap> scraps = scrapQueryService.getScrapsByMemberId(memberId);
         return CommonResponse.onSuccess(scraps.stream().map(ScrapConverter::toReadDTO).toList());
+    }
+
+    @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 V2", description = "내 스크랩을 조회하는 API입니다.")
+    @GetMapping("/v2/scraps/briefings/members/{memberId}")
+    public CommonResponse<List<ScrapResponse.ReadDTOV2>> getScrapsByMemberV2(@PathVariable Long memberId) {
+        List<Scrap> scraps = scrapQueryService.getScrapsByMemberId(memberId);
+        return CommonResponse.onSuccess(scraps.stream().map(ScrapConverter::toReadDTOV2).toList());
     }
 }

--- a/src/main/java/briefing/scrap/api/ScrapConverter.java
+++ b/src/main/java/briefing/scrap/api/ScrapConverter.java
@@ -38,6 +38,16 @@ public class ScrapConverter {
                 .title(scrap.getBriefing().getTitle())
                 .subtitle(scrap.getBriefing().getSubtitle())
                 .date(scrap.getBriefing().getCreatedAt().toLocalDate())
+                .build();
+    }
+
+    public static ScrapResponse.ReadDTOV2 toReadDTOV2(Scrap scrap) {
+        return ScrapResponse.ReadDTOV2.builder()
+                .briefingId(scrap.getBriefing().getId())
+                .ranks(scrap.getBriefing().getRanks())
+                .title(scrap.getBriefing().getTitle())
+                .subtitle(scrap.getBriefing().getSubtitle())
+                .date(scrap.getBriefing().getCreatedAt().toLocalDate())
                 .gptModel(scrap.getBriefing().getGptModel())
                 .timeOfDay(scrap.getBriefing().getTimeOfDay())
                 .build();

--- a/src/main/java/briefing/scrap/application/dto/ScrapResponse.java
+++ b/src/main/java/briefing/scrap/application/dto/ScrapResponse.java
@@ -33,12 +33,23 @@ public class ScrapResponse {
         private LocalDateTime deletedAt;
     }
 
-
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ReadDTO {
+        private Long briefingId;
+        private Integer ranks;
+        private String title;
+        private String subtitle;
+        private LocalDate date;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReadDTOV2 {
         private Long briefingId;
         private Integer ranks;
         private String title;

--- a/src/main/java/briefing/security/config/SecurityConfig.java
+++ b/src/main/java/briefing/security/config/SecurityConfig.java
@@ -84,9 +84,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> {
                     authorize.requestMatchers("/v2/briefings/**").permitAll();  // 모두 접근 가능합니다.
                     authorize.requestMatchers("/briefings/**").permitAll();  // 모두 접근 가능합니다.
+                    authorize.requestMatchers("/v2/members/auth/**").permitAll();
                     authorize.requestMatchers("/members/auth/**").permitAll();
                     authorize.requestMatchers("/chattings/**").permitAll();
+                    authorize.requestMatchers(HttpMethod.DELETE, "/v2/members/{memberId}").authenticated();
                     authorize.requestMatchers(HttpMethod.DELETE, "/members/{memberId}").authenticated();
+                    authorize.requestMatchers("/v2/scraps/**").authenticated();
                     authorize.requestMatchers("/scraps/**").authenticated();
                     authorize.anyRequest().authenticated();
                 })


### PR DESCRIPTION
# 🚀 개요
v1와 v2를 나눕니다.

## ⏳ 작업 내용
- [x] 기존 API v2버전으로 생성

### 📝 논의사항
v2 이후부터는 pathVariable로 받고 응답을 제네릭하게 만들고 서비스계층에서 전략패턴을 사용하면 될 것 같은데, v1의 API들은 앞에 v1이 붙지 않아서 어쩔 수 없이 이번에는 맛없게 중복코드를 양산하게 되었습니다...

