### PR TITLE
Feature/96: 스크랩 동시성 이슈 방지하기

### DIFF
--- a/src/main/java/briefing/exception/ErrorCode.java
+++ b/src/main/java/briefing/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     // scrap 에러
     SCRAP_ALREADY_EXISTS(CONFLICT, "SCRAP_001", "이미 스크랩했습니다."),
     SCRAP_NOT_FOUND(NOT_FOUND, "SCRAP_002", "존재하지 않는 스크랩입니다."),
+    DUPLICATE_SCRAP(CONFLICT, "SCRAP_003", "중복된 스크랩 요청입니다."),
 
     // briefing 에러
     NOT_FOUND_BRIEFING(NOT_FOUND,"BRIEFING_001", "브리핑이 존재하지 않습니다."),

--- a/src/main/java/briefing/scrap/application/ScrapCommandService.java
+++ b/src/main/java/briefing/scrap/application/ScrapCommandService.java
@@ -13,6 +13,7 @@ import briefing.scrap.domain.Scrap;
 import briefing.scrap.domain.repository.ScrapRepository;
 import briefing.scrap.exception.ScrapException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +41,13 @@ public class ScrapCommandService {
         Scrap scrap = ScrapConverter.toScrap(member, briefing);
 
         // Scrap 엔티티 저장 및 반환
-        return scrapRepository.save(scrap);
+        try {
+            // Scrap 엔티티 저장 및 반환
+            return scrapRepository.save(scrap);
+        } catch (DataIntegrityViolationException e) {
+            // 중복 스크랩 예외 처리
+            throw new ScrapException(ErrorCode.DUPLICATE_SCRAP);
+        }
     }
 
     public Scrap delete(Long briefingId, Long memberId) {

--- a/src/main/java/briefing/scrap/domain/Scrap.java
+++ b/src/main/java/briefing/scrap/domain/Scrap.java
@@ -10,6 +10,9 @@ import lombok.*;
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "briefing_id"})
+})
 public class Scrap extends BaseDateTimeEntity {
 
     @Id


### PR DESCRIPTION
# 🚀 개요
스크랩에 복합 유니크 제약조건을 추가하여 따닥을 방지했습니다.

## ⏳ 작업 내용
- [x] 유니크 제약조건 설정
- [x] 예외 핸들링 & 응답

### 📝 논의사항
동시성 이슈 해결방법(분산락, Version 어노테이션, ...) 여러가지가 있지만 가장 간단한 유니크 제약조건으로 했습니다.

