### PR TITLE
✨  Feat: 브리핑 목록 조회 v1 쿼리 전략 변경

### DIFF
--- a/src/main/java/briefing/briefing/application/BriefingQueryService.java
+++ b/src/main/java/briefing/briefing/application/BriefingQueryService.java
@@ -3,11 +3,7 @@ package briefing.briefing.application;
 import briefing.briefing.application.context.BriefingQueryContext;
 import briefing.briefing.application.context.BriefingQueryContextFactory;
 import briefing.briefing.application.dto.BriefingRequestParam;
-import briefing.briefing.application.strategy.BriefingV1QueryStrategy;
 import briefing.briefing.domain.Briefing;
-import briefing.briefing.domain.repository.BriefingRepository;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 import briefing.common.enums.APIVersion;

--- a/src/main/java/briefing/briefing/application/strategy/BriefingV1QueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingV1QueryStrategy.java
@@ -2,6 +2,7 @@ package briefing.briefing.application.strategy;
 
 import briefing.briefing.application.dto.BriefingRequestParam;
 import briefing.briefing.domain.Briefing;
+import briefing.briefing.domain.BriefingType;
 import briefing.briefing.domain.repository.BriefingRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -20,8 +21,9 @@ public class BriefingV1QueryStrategy implements BriefingQueryStrategy {
         final LocalDateTime startDateTime = params.getDate().atStartOfDay();
         final LocalDateTime endDateTime = params.getDate().atTime(LocalTime.MAX);
 
-        return briefingRepository.findAllByTypeAndCreatedAtBetweenOrderByRanks(
-                params.getType(), startDateTime, endDateTime);
+        List<Briefing> briefingList = briefingRepository.findAllByTypeAndCreatedAtBetweenOrderByRanks(params.getType(), startDateTime, endDateTime);
+        if(briefingList.isEmpty()) return briefingRepository.findTop10ByTypeOrderByCreatedAtDesc(BriefingType.SOCIAL);
+        return briefingList;
     }
 
     @Override


### PR DESCRIPTION
# 🚀 개요
v2를 릴리즈에 반영했을 때 DB에 쌓여있는 데이터 타입은 KOREA가 없어서 빈 리스트를 반환합니다.
앱 업데이트를 하지 않은 유저일때는 SOCIAL 타입 10개를 내려줍니다.

## ⏳ 작업 내용
- [x] KOREA로 조회시, 빈리스트이면 SOCIAL 10개를 내려줍니다.

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

