### PR TITLE
♻️  Refactor: OCP를 준수하는 방향으로 전략 패턴 코드 리팩토링

### DIFF
--- a/src/main/java/briefing/briefing/application/BriefingQueryService.java
+++ b/src/main/java/briefing/briefing/application/BriefingQueryService.java
@@ -18,13 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BriefingQueryService {
 
+  private final BriefingQueryContextFactory briefingQueryContextFactory;
+
   public List<Briefing> findBriefings(BriefingRequestParam.BriefingPreviewListParam params, APIVersion version) {
-    BriefingQueryContext briefingQueryContext = BriefingQueryContextFactory.getContextByVersion(version);
+    BriefingQueryContext briefingQueryContext = briefingQueryContextFactory.getContextByVersion(version);
     return briefingQueryContext.findBriefings(params);
   }
 
   public Briefing findBriefing(final Long id, final APIVersion version) {
-    BriefingQueryContext briefingQueryContext = BriefingQueryContextFactory.getContextByVersion(version);
+    BriefingQueryContext briefingQueryContext = briefingQueryContextFactory.getContextByVersion(version);
     return briefingQueryContext.findById(id)
         .orElseThrow(() -> new BriefingException(ErrorCode.NOT_FOUND_BRIEFING));
   }

--- a/src/main/java/briefing/briefing/application/strategy/BriefingQueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingQueryStrategy.java
@@ -2,6 +2,7 @@ package briefing.briefing.application.strategy;
 
 import briefing.briefing.application.dto.BriefingRequestParam;
 import briefing.briefing.domain.Briefing;
+import briefing.common.enums.APIVersion;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +11,6 @@ public interface BriefingQueryStrategy {
     List<Briefing> findBriefings(BriefingRequestParam.BriefingPreviewListParam params);
 
     Optional<Briefing> findById(Long id);
+
+    APIVersion getVersion();
 }

--- a/src/main/java/briefing/briefing/application/strategy/BriefingV1QueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingV1QueryStrategy.java
@@ -4,7 +4,9 @@ import briefing.briefing.application.dto.BriefingRequestParam;
 import briefing.briefing.domain.Briefing;
 import briefing.briefing.domain.BriefingType;
 import briefing.briefing.domain.repository.BriefingRepository;
+import briefing.common.enums.APIVersion;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -12,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+@Component
 @RequiredArgsConstructor
 public class BriefingV1QueryStrategy implements BriefingQueryStrategy {
 
@@ -33,5 +36,10 @@ public class BriefingV1QueryStrategy implements BriefingQueryStrategy {
     @Override
     public Optional<Briefing> findById(Long id) {
         return briefingRepository.findById(id);
+    }
+
+    @Override
+    public APIVersion getVersion() {
+        return APIVersion.V1;
     }
 }

--- a/src/main/java/briefing/briefing/application/strategy/BriefingV2QueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingV2QueryStrategy.java
@@ -3,7 +3,9 @@ package briefing.briefing.application.strategy;
 import briefing.briefing.application.dto.BriefingRequestParam;
 import briefing.briefing.domain.Briefing;
 import briefing.briefing.domain.repository.BriefingRepository;
+import briefing.common.enums.APIVersion;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -11,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+@Component
 @RequiredArgsConstructor
 public class BriefingV2QueryStrategy implements BriefingQueryStrategy{
 
@@ -34,5 +37,10 @@ public class BriefingV2QueryStrategy implements BriefingQueryStrategy{
     @Override
     public Optional<Briefing> findById(Long id) {
         return briefingRepository.findByIdWithScrapCount(id);
+    }
+
+    @Override
+    public APIVersion getVersion() {
+        return APIVersion.V2;
     }
 }


### PR DESCRIPTION
# 🚀 개요
기존 코드는 버전이 추가될때 BriefingQueryContextFactory 팩토리 클래스에 수정이 발생하기 때문에 OCP를 위반했습니다. OCP를 준수하는 방향으로 전략만 확장할 수 있게 구현했습니다.

## ⏳ 작업 내용
기존에는 팩토리 클래스의 getContextByVersion메소드에서 switch case로 버전에 맞는 컨텍스트를 제공해서 버전이 추가되면 팩토리 클래스에 수정이 발생했었습니다.

각 전략을 빈으로 등록하고, 팩토리 클래스에서는 쿼리전략 빈 목록을 주입받아 컨텍스트를 만들어서 맵에 저장해둡니다. 이후 getContextByVersion 메소드로 적절한 컨텍스트를 클라이언트 코드에 제공합니다.

이제는 버전이 추가되면 팩토리 클래스 수정없이 해당하는 전략 클래스만 추가(확장에 해당)하면 됩니다. 

- 클래스 다이어그램
![image](https://github.com/Team-Shaka/Briefing-Backend/assets/53550707/96b3f447-1590-4115-b0a0-99602bc5f099)


### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

