### PR TITLE
✨  Feat: API 응답 캐싱을 통한 브리핑 V2 조회 속도 개선

### DIFF
--- a/src/main/java/briefing/BriefingApplication.java
+++ b/src/main/java/briefing/BriefingApplication.java
@@ -3,6 +3,7 @@ package briefing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
             @Server(url = "https://api.newsbreifing.store", description = "release server")
         })
 @SpringBootApplication
+@EnableCaching
 @EnableFeignClients
 @EnableRedisRepositories
 @ImportAutoConfiguration({FeignAutoConfiguration.class})

--- a/src/main/java/briefing/briefing/api/BriefingV2Api.java
+++ b/src/main/java/briefing/briefing/api/BriefingV2Api.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.*;
 
 import briefing.briefing.application.BriefingCommandService;
@@ -32,6 +33,7 @@ public class BriefingV2Api {
 
     @GetMapping("/briefings")
     @Operation(summary = "03-01Briefing \uD83D\uDCF0  브리핑 목록 조회 V2", description = "")
+    @Cacheable(value = "findBriefingsV2", key = "#params.toString()")
     public CommonResponse<BriefingResponseDTO.BriefingPreviewListDTOV2> findBriefingsV2(
             @ParameterObject @ModelAttribute BriefingRequestParam.BriefingPreviewListParam params) {
         List<Briefing> briefingList = briefingQueryService.findBriefings(params, APIVersion.V2);

--- a/src/main/java/briefing/briefing/application/dto/BriefingRequestParam.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingRequestParam.java
@@ -16,6 +16,7 @@ public class BriefingRequestParam {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
+    @ToString
     public static class BriefingPreviewListParam {
         @NotNull private BriefingType type;
         private LocalDate date;

--- a/src/main/java/briefing/common/response/CommonResponse.java
+++ b/src/main/java/briefing/common/response/CommonResponse.java
@@ -12,13 +12,19 @@ import lombok.Getter;
 public class CommonResponse<T> {
 
     @JsonProperty("isSuccess")
-    private final Boolean isSuccess;
+    private Boolean isSuccess;
 
-    private final String code;
-    private final String message;
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("result")
     private T result;
 
-    // 요청에 성공한 경우11
+    // 기본 생성자 추가
+    public CommonResponse() {}
 
     public static <T> CommonResponse<T> onSuccess(T data) {
         return new CommonResponse<>(true, "요청에 성공하였습니다.", "1000", data);

--- a/src/main/java/briefing/config/CacheConfig.java
+++ b/src/main/java/briefing/config/CacheConfig.java
@@ -1,0 +1,48 @@
+package briefing.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        PolymorphicTypeValidator typeValidator =
+                BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        RedisCacheConfiguration cacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .entryTtl(Duration.ofHours(1)) // 예: 캐시 유효 시간 1시간
+                        .disableCachingNullValues()
+                        .prefixCacheNameWith("responseCache::") // 캐시 키 접두사 설정
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer(objectMapper)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(cacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/briefing/config/CacheConfig.java
+++ b/src/main/java/briefing/config/CacheConfig.java
@@ -31,7 +31,7 @@ public class CacheConfig {
 
         RedisCacheConfiguration cacheConfiguration =
                 RedisCacheConfiguration.defaultCacheConfig()
-                        .entryTtl(Duration.ofHours(1)) // 예: 캐시 유효 시간 1시간
+                        .entryTtl(Duration.ofMinutes(30)) // 캐시 유효 시간 30분
                         .disableCachingNullValues()
                         .prefixCacheNameWith("responseCache::") // 캐시 키 접두사 설정
                         .serializeKeysWith(

--- a/src/main/java/briefing/scrap/api/ScrapV2Api.java
+++ b/src/main/java/briefing/scrap/api/ScrapV2Api.java
@@ -2,6 +2,7 @@ package briefing.scrap.api;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.web.bind.annotation.*;
 
 import briefing.common.response.CommonResponse;
@@ -22,6 +23,7 @@ public class ScrapV2Api {
     private final ScrapQueryService scrapQueryService;
     private final ScrapCommandService scrapCommandService;
 
+    @CacheEvict(value = "findBriefingsV2", allEntries = true)
     @Operation(summary = "05-01 Scrap📁 스크랩하기 V2", description = "브리핑을 스크랩하는 API입니다.")
     @PostMapping("/scraps/briefings")
     public CommonResponse<ScrapResponse.CreateDTOV2> createV2(
@@ -40,6 +42,7 @@ public class ScrapV2Api {
         return CommonResponse.onSuccess(ScrapConverter.toDeleteDTOV2(deletedScrap, scrapCount));
     }
 
+    @CacheEvict(value = "findBriefingsV2", allEntries = true)
     @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 V2", description = "내 스크랩을 조회하는 API입니다.")
     @GetMapping("/scraps/briefings/members/{memberId}")
     public CommonResponse<List<ScrapResponse.ReadDTOV2>> getScrapsByMemberV2(

--- a/src/main/java/briefing/scrap/api/ScrapV2Api.java
+++ b/src/main/java/briefing/scrap/api/ScrapV2Api.java
@@ -33,6 +33,7 @@ public class ScrapV2Api {
         return CommonResponse.onSuccess(ScrapConverter.toCreateDTOV2(createdScrap, scrapCount));
     }
 
+    @CacheEvict(value = "findBriefingsV2", allEntries = true)
     @Operation(summary = "05-02 Scrap📁 스크랩 취소 V2", description = "스크랩을 취소하는 API입니다.")
     @DeleteMapping("/scraps/briefings/{briefingId}/members/{memberId}")
     public CommonResponse<ScrapResponse.DeleteDTOV2> deleteV2(
@@ -42,7 +43,6 @@ public class ScrapV2Api {
         return CommonResponse.onSuccess(ScrapConverter.toDeleteDTOV2(deletedScrap, scrapCount));
     }
 
-    @CacheEvict(value = "findBriefingsV2", allEntries = true)
     @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 V2", description = "내 스크랩을 조회하는 API입니다.")
     @GetMapping("/scraps/briefings/members/{memberId}")
     public CommonResponse<List<ScrapResponse.ReadDTOV2>> getScrapsByMemberV2(


### PR DESCRIPTION
## 🚀 개요
- close #118 
자주 호출되고 응답이 잘 바뀌지 않는 브리핑 목록 조회 API 응답을 캐싱하여 조회 속도를 개선했습니다.
실제로 개선된 지표와 개발과정은 블로그 글을 통해 자세히 기록하겠습니다.

## ⏳ 작업 내용
- 캐시 이름은 컨트롤러 메소드명(findBriefingsV2)으로 작성했으며, responseCache라는 접두사를 붙도록 해두었습니다.
- 파라미터별로 응답이 다르게 캐싱되어야하므로 키는 #params.toString()으로 작성했습니다.
- 스크랩개수 정합성을 보장하기 위하여 스크랩 & 취소시에 캐시를 비우도록 했습니다.



### 📝 논의사항
현재는 스크랩시, 스크랩 취소 시 해당하는 브리핑이 포함된 값들만 비우지않고, findBriefingsV2캐시의 모든 값을 비웁니다.
이 부분은 포함된 값들만 찾아서 비울 것인지 고민을 조금 더 해봐야할 것 같습니다. 정확히하려면 API 로그를 분석해서 스크랩이 발생하는 비율을 따져보고 결정해야할 것 같습니다. 개인적으로는 쓸데없이 검사하는 비용을 더 들이는 느낌이라서 지금처럼 유지해도 좋다고 생각합니다. 
