### PR TITLE
✨  Feat : 브리핑 수정 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/src/main/java/briefing/briefing/api/BriefingApi.java
+++ b/src/main/java/briefing/briefing/api/BriefingApi.java
@@ -3,6 +3,7 @@ package briefing.briefing.api;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -68,5 +69,30 @@ public class BriefingApi {
     @Operation(summary = "03-03Briefing \uD83D\uDCF0  브리핑 등록", description = "")
     public void createBriefing(@RequestBody final BriefingRequestDTO.BriefingCreate request) {
         briefingCommandService.createBriefing(request);
+    }
+
+
+    /*
+     * TODO 브리핑 수정 API는 우선적으로 인가 처리를 진행하지 않으나
+     *  빠른 시일 내로 브리핑 등록과 함께 인가 처리 예정
+     *  즉 유저에게 권한을 부여하는 일련의 과정에 대한 리팩토링이 필요함 이는 CYY1007이 진행하겠음
+     */
+
+    /**
+     *
+     * @param id, BriefingResponseDTO.BriefingUpdateDTO
+     * @return 수정된 값, 요청으로 온 값과 동일
+     */
+
+    @Operation(summary = "03-04Briefing \uD83D\uDCF0  브리핑 내용 수정", description = "")
+    @Parameter(name = "id", description = "브리핑 아이디", example = "1")
+    @PatchMapping("/briefings/{id}")
+    public CommonResponse<BriefingResponseDTO.BriefingUpdateDTO> patchBriefingContent(
+            @PathVariable(name = "id") Long id,
+            @RequestBody @Valid BriefingRequestDTO.BriefingUpdateDTO request
+    ){
+
+        Briefing briefing = briefingCommandService.updateBriefing(id, request);
+        return CommonResponse.onSuccess(BriefingConverter.toBriefingUpdateDTO(briefing));
     }
 }

--- a/src/main/java/briefing/briefing/api/BriefingConverter.java
+++ b/src/main/java/briefing/briefing/api/BriefingConverter.java
@@ -196,4 +196,13 @@ public class BriefingConverter {
                 .briefings(tempDTOList)
                 .build();
     }
+
+    public static BriefingResponseDTO.BriefingUpdateDTO toBriefingUpdateDTO(Briefing briefing){
+        return BriefingResponseDTO.BriefingUpdateDTO
+                .builder()
+                .title(briefing.getTitle())
+                .subTitle(briefing.getSubtitle())
+                .content(briefing.getContent())
+                .build();
+    }
 }

--- a/src/main/java/briefing/briefing/application/BriefingCommandService.java
+++ b/src/main/java/briefing/briefing/application/BriefingCommandService.java
@@ -1,7 +1,10 @@
 package briefing.briefing.application;
 
 import java.util.List;
+import java.util.Optional;
 
+import briefing.exception.ErrorCode;
+import briefing.exception.handler.BriefingException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +17,8 @@ import briefing.briefing.domain.repository.ArticleRepository;
 import briefing.briefing.domain.repository.BriefingArticleRepository;
 import briefing.briefing.domain.repository.BriefingRepository;
 import lombok.RequiredArgsConstructor;
+
+import javax.swing.text.html.Option;
 
 @Service
 @Transactional
@@ -35,5 +40,19 @@ public class BriefingCommandService {
         final List<BriefingArticle> briefingArticles =
                 articles.stream().map(article -> new BriefingArticle(briefing, article)).toList();
         briefingArticleRepository.saveAll(briefingArticles);
+    }
+
+    public Briefing updateBriefing(Long id, final BriefingRequestDTO.BriefingUpdateDTO request){
+
+        // throw 부분을 컨트롤러에서 validator annotation을 사용하는 것이 더 좋을지??
+        Briefing briefing = briefingRepository.findById(id).orElseThrow(() -> new BriefingException(ErrorCode.NOT_FOUND_BRIEFING));
+
+
+        // 이 코드 더 깔끔하게 리팩토링이 가능할지??
+        Optional.ofNullable(request.getContent()).ifPresent(briefing::setContent);
+        Optional.ofNullable(request.getTitle()).ifPresent(briefing::setTitle);
+        Optional.ofNullable(request.getSubTitle()).ifPresent(briefing::setSubtitle);
+
+        return briefing;
     }
 }

--- a/src/main/java/briefing/briefing/application/BriefingCommandService.java
+++ b/src/main/java/briefing/briefing/application/BriefingCommandService.java
@@ -44,14 +44,9 @@ public class BriefingCommandService {
 
     public Briefing updateBriefing(Long id, final BriefingRequestDTO.BriefingUpdateDTO request){
 
-        // throw 부분을 컨트롤러에서 validator annotation을 사용하는 것이 더 좋을지??
         Briefing briefing = briefingRepository.findById(id).orElseThrow(() -> new BriefingException(ErrorCode.NOT_FOUND_BRIEFING));
 
-
-        // 이 코드 더 깔끔하게 리팩토링이 가능할지??
-        Optional.ofNullable(request.getContent()).ifPresent(briefing::setContent);
-        Optional.ofNullable(request.getTitle()).ifPresent(briefing::setTitle);
-        Optional.ofNullable(request.getSubTitle()).ifPresent(briefing::setSubtitle);
+        briefing.updateBriefing(request.getTitle(),request.getSubTitle(),request.getContent());
 
         return briefing;
     }

--- a/src/main/java/briefing/briefing/application/dto/BriefingRequestDTO.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingRequestDTO.java
@@ -7,7 +7,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import briefing.briefing.domain.BriefingType;
 import briefing.briefing.domain.TimeOfDay;
 import briefing.chatting.domain.GptModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class BriefingRequestDTO {
 
@@ -35,5 +38,12 @@ public class BriefingRequestDTO {
         GptModel gptModel = GptModel.GPT_4;
         TimeOfDay timeOfDay = TimeOfDay.MORNING;
         BriefingType briefingType = BriefingType.KOREA;
+    }
+
+    @Getter
+    public static class BriefingUpdateDTO{
+        String title;
+        String subTitle;
+        String content;
     }
 }

--- a/src/main/java/briefing/briefing/application/dto/BriefingResponseDTO.java
+++ b/src/main/java/briefing/briefing/application/dto/BriefingResponseDTO.java
@@ -125,4 +125,14 @@ public class BriefingResponseDTO {
         String subtitle;
         Integer scrapCount;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BriefingUpdateDTO{
+        String title;
+        String subTitle;
+        String content;
+    }
 }

--- a/src/main/java/briefing/briefing/domain/Briefing.java
+++ b/src/main/java/briefing/briefing/domain/Briefing.java
@@ -53,4 +53,16 @@ public class Briefing extends BaseDateTimeEntity {
     public void setScrapCount(Integer scrapCount) {
         this.scrapCount = scrapCount;
     }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setSubtitle(String subtitle) {
+        this.subtitle = subtitle;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/briefing/briefing/domain/Briefing.java
+++ b/src/main/java/briefing/briefing/domain/Briefing.java
@@ -2,6 +2,7 @@ package briefing.briefing.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.persistence.*;
 
@@ -64,5 +65,11 @@ public class Briefing extends BaseDateTimeEntity {
 
     public void setContent(String content) {
         this.content = content;
+    }
+
+    public void updateBriefing(String title, String subtitle, String content){
+        Optional.ofNullable(title).ifPresent(this::setTitle);
+        Optional.ofNullable(subtitle).ifPresent(this::setSubtitle);
+        Optional.ofNullable(content).ifPresent(this::setContent);
     }
 }


### PR DESCRIPTION
# 🚀 개요
브리핑 수정 API 구현

## 🔍 변경사항

브리핑 수정이 가능한 API가 추가가 되었습니다.

해당 API는 제목, 소제목, 내용에 대한 수정이 가능하며

당장은 jwt 토큰을 이용해 인증을 거치도록 해 두었습니다.

이에 대해 또 다른 의견 있으시다면 코멘트 부탁 드립니다!


## ⏳ 작업 내용
- [x] 브리핑 수정 API 구현

### 📝 논의사항

🙌🙌 코드에 주석으로 처리 된 부분에 대해서 리뷰어님의 의견을 남겨주시길 바랍니다.


