### PR TITLE
🐛 Fix: 브리핑 목록 조회 순위 버그 해결

### DIFF
--- a/src/main/java/briefing/briefing/application/strategy/BriefingV1QueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingV1QueryStrategy.java
@@ -2,7 +2,6 @@ package briefing.briefing.application.strategy;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +31,6 @@ public class BriefingV1QueryStrategy implements BriefingQueryStrategy {
         if (briefingList.isEmpty()) {
             briefingList =
                     briefingRepository.findTop10ByTypeOrderByCreatedAtDesc(BriefingType.SOCIAL);
-            Collections.reverse(briefingList);
         }
         return briefingList;
     }

--- a/src/main/java/briefing/briefing/application/strategy/BriefingV2QueryStrategy.java
+++ b/src/main/java/briefing/briefing/application/strategy/BriefingV2QueryStrategy.java
@@ -2,7 +2,6 @@ package briefing.briefing.application.strategy;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,7 +33,6 @@ public class BriefingV2QueryStrategy implements BriefingQueryStrategy {
         }
 
         briefingList = briefingRepository.findTop10ByTypeOrderByCreatedAtDesc(params.getType());
-        Collections.reverse(briefingList);
         return briefingList;
     }
 

--- a/src/main/java/briefing/briefing/domain/repository/BriefingCustomRepositoryImpl.java
+++ b/src/main/java/briefing/briefing/domain/repository/BriefingCustomRepositoryImpl.java
@@ -78,7 +78,7 @@ public class BriefingCustomRepositoryImpl implements BriefingCustomRepository {
                         .on(scrap.briefing.eq(briefing))
                         .where(briefing.type.eq(type))
                         .groupBy(briefing)
-                        .orderBy(date.desc(), briefing.ranks.desc())
+                        .orderBy(date.desc(), briefing.ranks.asc())
                         .limit(10)
                         .fetch();
 

--- a/src/main/java/briefing/briefing/domain/repository/BriefingCustomRepositoryImpl.java
+++ b/src/main/java/briefing/briefing/domain/repository/BriefingCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package briefing.briefing.domain.repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,6 +10,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import briefing.briefing.domain.Briefing;
@@ -61,6 +65,11 @@ public class BriefingCustomRepositoryImpl implements BriefingCustomRepository {
         QBriefing briefing = QBriefing.briefing;
         QScrap scrap = QScrap.scrap;
 
+        DateTimePath<LocalDateTime> dateTime = briefing.createdAt;
+        DateTemplate<LocalDate> date =
+                Expressions.dateTemplate(
+                        LocalDate.class, "DATE_FORMAT({0}, {1})", dateTime, "%Y-%m-%d");
+
         List<Tuple> results =
                 queryFactory
                         .select(briefing, scrap.count())
@@ -69,7 +78,7 @@ public class BriefingCustomRepositoryImpl implements BriefingCustomRepository {
                         .on(scrap.briefing.eq(briefing))
                         .where(briefing.type.eq(type))
                         .groupBy(briefing)
-                        .orderBy(briefing.createdAt.desc())
+                        .orderBy(date.desc(), briefing.ranks.desc())
                         .limit(10)
                         .fetch();
 


### PR DESCRIPTION
# 🚀 개요
브리핑 생성 시 순서가 섞였을 때,
목록 조회시에도 동일하게 잘못된 순서로 내려갔었습니다.

## ⏳ 작업 내용
- 해당하는 쿼리의 order by 절을 변경하여 해결했습니다.

### 📝 논의사항
시간을 제외한 날짜로만 역순정렬을 한 후 순위 정렬을 해야해서
DATE_FORMAT 함수를 사용했는데, 디비 의존적이라 고민이 필요할 것 같습니다.
