### PR TITLE
📝  Docs :  인증처리가 필요한 API 대상 토큰 관련 명세 진행

### DIFF
--- a/Briefing-Api/src/main/java/com/example/briefingapi/scrap/presentation/ScrapApi.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/scrap/presentation/ScrapApi.java
@@ -5,6 +5,10 @@ import com.example.briefingapi.scrap.business.ScrapFacade;
 import com.example.briefingapi.scrap.presentation.dto.ScrapRequest;
 import com.example.briefingapi.scrap.presentation.dto.ScrapResponse;
 import com.example.briefingcommon.common.presentation.response.CommonResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,6 +23,25 @@ public class ScrapApi {
 
     @Operation(summary = "05-01 Scrap📁 스크랩하기 V1", description = "브리핑을 스크랩하는 API입니다.")
     @PostMapping("/scraps/briefings")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<ScrapResponse.CreateDTO> create(
             @RequestBody final ScrapRequest.CreateDTO request) {
         return CommonResponse.onSuccess(scrapFacade.create(request));
@@ -26,6 +49,25 @@ public class ScrapApi {
 
     @Operation(summary = "05-02 Scrap📁 스크랩 취소 V1", description = "스크랩을 취소하는 API입니다.")
     @DeleteMapping("/scraps/briefings/{briefingId}/members/{memberId}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<ScrapResponse.DeleteDTO> delete(
             @PathVariable final Long briefingId, @PathVariable final Long memberId) {
         return CommonResponse.onSuccess(scrapFacade.delete(briefingId, memberId));
@@ -33,6 +75,25 @@ public class ScrapApi {
 
     @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 V1", description = "내 스크랩을 조회하는 API입니다.")
     @GetMapping("/scraps/briefings/members/{memberId}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<List<ScrapResponse.ReadDTO>> getScrapsByMember(
             @PathVariable final Long memberId) {
         return CommonResponse.onSuccess(scrapFacade.getScrapsByMemberId(memberId));

--- a/Briefing-Api/src/main/java/com/example/briefingapi/scrap/presentation/ScrapV2Api.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/scrap/presentation/ScrapV2Api.java
@@ -5,6 +5,10 @@ import com.example.briefingapi.scrap.business.ScrapV2Facade;
 import com.example.briefingapi.scrap.presentation.dto.ScrapRequest;
 import com.example.briefingapi.scrap.presentation.dto.ScrapResponse;
 import com.example.briefingcommon.common.presentation.response.CommonResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 
 import com.example.briefingapi.aop.annotation.CacheEvictByBriefingId;
@@ -22,6 +26,25 @@ public class ScrapV2Api {
     @CacheEvictByBriefingId(value = "findBriefingsV2", briefingId = "#request.getBriefingId()")
     @Operation(summary = "05-01 Scrap📁 스크랩하기 V2", description = "브리핑을 스크랩하는 API입니다.")
     @PostMapping("/scraps/briefings")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<ScrapResponse.CreateDTOV2> createV2(
             @RequestBody final ScrapRequest.CreateDTO request) {
         return CommonResponse.onSuccess(scrapFacade.create(request));
@@ -30,6 +53,25 @@ public class ScrapV2Api {
     @CacheEvictByBriefingId(value = "findBriefingsV2", briefingId = "#briefingId")
     @Operation(summary = "05-02 Scrap📁 스크랩 취소 V2", description = "스크랩을 취소하는 API입니다.")
     @DeleteMapping("/scraps/briefings/{briefingId}/members/{memberId}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<ScrapResponse.DeleteDTOV2> deleteV2(
             @PathVariable final Long briefingId, @PathVariable final Long memberId) {
         return CommonResponse.onSuccess(scrapFacade.delete(briefingId, memberId));
@@ -37,6 +79,25 @@ public class ScrapV2Api {
 
     @Operation(summary = "05-03 Scrap📁 내 스크랩 조회 V2", description = "내 스크랩을 조회하는 API입니다.")
     @GetMapping("/scraps/briefings/members/{memberId}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<List<ScrapResponse.ReadDTOV2>> getScrapsByMemberV2(
             @PathVariable final Long memberId) {
         return CommonResponse.onSuccess(scrapFacade.getScrapsByMemberId(memberId));


### PR DESCRIPTION
# 🚀 개요
인증처리가 필요한 API 대상 토큰 관련 명세 진행

## 🔍 변경사항

- 인증이 필요한 presentation 계층의 Controller에 Swagger 명세가 추가되었습니다.

## ⏳ 작업 내용
- [x] 인증이 필요한 API 대상으로 토큰과 관련된 명세를 진행

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

