### PR TITLE
Bug/181 리프레시 토큰 로직 수정

### DIFF
--- a/Briefing-Api/src/main/java/com/example/briefingapi/member/presentation/MemberApi.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/member/presentation/MemberApi.java
@@ -45,6 +45,13 @@ public class MemberApi {
 
     @Operation(summary = "02-01 Member\uD83D\uDC64 소셜 로그인 V1", description = "구글, 애플 소셜로그인 API입니다.")
     @PostMapping("/members/auth/{socialType}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "COMMON001",
+                    description = "request body에 담길 값이 이상함, result를 확인해주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
     public CommonResponse<MemberResponse.LoginDTO> login(
             @Parameter(description = "소셜로그인 종류", example = "google") @PathVariable
                     final SocialType socialType,

--- a/Briefing-Api/src/main/resources/application.yml
+++ b/Briefing-Api/src/main/resources/application.yml
@@ -119,7 +119,7 @@ jwt:
   secret: ${JWT_SECRET}
   #  secret : ${JWT_SECRET}
   authorities-key: authoritiesKey
-  access-token-validity-in-seconds: 1210000000 # 30 m
+  access-token-validity-in-seconds: 30 # 30 m
   refresh-token-validity-in-seconds: 1210000000 # 14 d
 
 openai:
@@ -159,7 +159,7 @@ jwt:
   secret: ${JWT_SECRET}
   #  secret : ${JWT_SECRET}
   authorities-key: authoritiesKey
-  access-token-validity-in-seconds: 1210000000 # 30 m
+  access-token-validity-in-seconds: 1800 # 30 m
   refresh-token-validity-in-seconds: 1210000000 # 14 d
 
 openai:


### PR DESCRIPTION
# 🚀 개요

리프레시 토큰 재발급 시 access token의 유효시간과 현재 리프레시 토큰의 유효시간을 계산했으나
이러한 로직이 버그를 발생시키고
추가로 보안성을 위해 리프레시 토큰은 access Token 재발급 시 무조건 같이 재 발급 되도록 수정합니다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 리프레시 토큰이 매번 재발급

## ⏳ 작업 내용
- [x] 리프레시 토큰 로직 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

