### PR TITLE
✨  Feat : 푸쉬알람 허용 V2 구현

### DIFF
--- a/Briefing-Api/src/main/java/com/example/briefingapi/member/presentation/MemberV2Api.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/member/presentation/MemberV2Api.java
@@ -47,6 +47,35 @@ public class MemberV2Api {
         return CommonResponse.onSuccess(memberFacade.login(socialType, request));
     }
 
+    @Operation(summary = "02-04 Member\uD83D\uDC64 푸쉬 알람 허용/거부 설정 V2 ", description = "푸쉬 알람 허용/거부 설정입니다.")
+    @PostMapping("/members/alarms")
+    @ApiResponses({
+            @ApiResponse(responseCode = "1000", description = "OK, 성공"),
+            @ApiResponse(
+                    responseCode = "AUTH003",
+                    description = "access 토큰을 주세요!",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH004",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "AUTH006",
+                    description = "acess 토큰 모양이 이상함",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(
+                    responseCode = "MEMBER_001",
+                    description = "사용자가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+    })
+    public CommonResponse<Void> subscribeDailyPush(
+            @Valid @RequestBody MemberRequest.ToggleDailyPushAlarmDTO request,
+            @Parameter(hidden = true) @AuthMember Member member
+    ){
+        memberFacade.subScribeDailyPush(request,member);
+        return CommonResponse.onSuccess();
+    }
+
     @Operation(
             summary = "02-01 Member\uD83D\uDC64 accessToken 재발급 받기 V2",
             description = "accessToken 만료 시 refreshToken으로 재발급을 받는 API 입니다.")

--- a/Briefing-Api/src/main/java/com/example/briefingapi/security/handler/JwtAuthenticationEntryPoint.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/security/handler/JwtAuthenticationEntryPoint.java
@@ -31,8 +31,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         ApiErrorResult apiErrorResult =
                 ApiErrorResult.builder()
                         .isSuccess(false)
-                        .code(ErrorCode._UNAUTHORIZED.getCode())
-                        .message(ErrorCode._UNAUTHORIZED.getMessage())
+                        .code(ErrorCode.UNAUTHORIZED_EXCEPTION.getCode())
+                        .message(ErrorCode.UNAUTHORIZED_EXCEPTION.getMessage())
                         .result(null)
                         .build();
         try {

--- a/Briefing-Api/src/main/resources/application.yml
+++ b/Briefing-Api/src/main/resources/application.yml
@@ -66,7 +66,7 @@ jwt:
   # dev server
   secret: ${JWT_SECRET}
   authorities-key: authoritiesKey
-  access-token-validity-in-seconds: 30000
+  access-token-validity-in-seconds: 1200000
   refresh-token-validity-in-seconds: 1210000000 # 14 d
 
 openai:


### PR DESCRIPTION
# 🚀 개요
✨  Feat : 푸쉬알람 허용 V2 구현

## 🔍 변경사항

-  푸쉬알람 허용 API V2 구현
- Jwt 에러 처리 핸들러 응답 json 수정

이제 JWT 토큰이 없어서 발생하는 인증 실패는 AUTH03 에러가 응답으로 전달됩니다.

## ⏳ 작업 내용
- [x] 푸쉬알람 허용 API V2 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

