### PR TITLE
Feature/194 : 브리핑 조회수 증가

### DIFF
--- a/Briefing-Api/src/main/java/com/example/briefingapi/briefing/business/BriefingFacade.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/briefing/business/BriefingFacade.java
@@ -39,8 +39,9 @@ public class BriefingFacade {
         return BriefingConverter.toBriefingPreviewListDTO(params.getDate(), briefingList);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public BriefingResponseDTO.BriefingDetailDTO findBriefing(final Long id, Member member) {
+        briefingCommandService.increaseViewCountById(id);
         Boolean isScrap =
                 Optional.ofNullable(member)
                         .map(m -> scrapQueryService.existsByMemberIdAndBriefingId(m.getId(), id))

--- a/Briefing-Api/src/main/java/com/example/briefingapi/briefing/business/BriefingV2Facade.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/briefing/business/BriefingV2Facade.java
@@ -3,6 +3,7 @@ package com.example.briefingapi.briefing.business;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.briefingapi.briefing.implement.service.BriefingCommandService;
 import com.example.briefingapi.briefing.implement.service.BriefingQueryService;
 import com.example.briefingapi.briefing.presentation.dto.BriefingRequestParam;
 import com.example.briefingapi.briefing.presentation.dto.BriefingResponseDTO;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class BriefingV2Facade {
 
     private final BriefingQueryService briefingQueryService;
+    private final BriefingCommandService briefingCommandService;
     private final ScrapQueryService scrapQueryService;
     private static final APIVersion version = APIVersion.V2;
 
@@ -30,8 +32,9 @@ public class BriefingV2Facade {
         return BriefingConverter.toBriefingPreviewListDTOV2(params.getDate(), briefingList);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public BriefingResponseDTO.BriefingDetailDTOV2 findBriefing(final Long id, Member member) {
+        briefingCommandService.increaseViewCountById(id);
         Boolean isScrap =
                 Optional.ofNullable(member)
                         .map(m -> scrapQueryService.existsByMemberIdAndBriefingId(m.getId(), id))

--- a/Briefing-Api/src/main/java/com/example/briefingapi/briefing/implement/service/BriefingCommandService.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/briefing/implement/service/BriefingCommandService.java
@@ -21,4 +21,8 @@ public class BriefingCommandService {
         briefing.updateBriefing(title, subTitle, content);
         return briefing;
     }
+
+    public void increaseViewCountById(final Long id) {
+        briefingRepository.updateViewCountById(id);
+    }
 }

--- a/Briefing-Api/src/main/java/com/example/briefingapi/security/config/SecurityConfig.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/security/config/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
         return (web) ->
                 web.ignoring()
                         .requestMatchers(
-                                "","/",
+                                "/",
                                 "/schedule",
                                 "/v3/api-docs",
                                 "/v3/api-docs/**",

--- a/Briefing-Api/src/main/resources/application.yml
+++ b/Briefing-Api/src/main/resources/application.yml
@@ -170,3 +170,40 @@ openai:
   token: ${OPEN_API_TOKEN}
   url:
     chat: https://api.openai.com/v1/chat/completions
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        ddl-hbm2ddl:
+          auto: create
+        #        show_sql: true
+        #        format_sql: true
+        #        use_sql_comments: true
+        default_batch_fetch_size: 1000
+  data:
+    redis:
+      host: ${REDIS_URL}
+      port: 6379
+jwt:
+  header: Authorization
+  # dev server
+  secret: ${JWT_SECRET}
+  #  secret : ${JWT_SECRET}
+  authorities-key: authoritiesKey
+  access-token-validity-in-seconds: 30000 # 30 m
+  refresh-token-validity-in-seconds: 1210000000 # 14 d
+
+openai:
+  token: ${OPEN_API_TOKEN}
+  url:
+    chat: https://api.openai.com/v1/chat/completions

--- a/Briefing-Api/src/test/java/com/example/briefingapi/briefing/presentation/BriefingV2ApiTest.java
+++ b/Briefing-Api/src/test/java/com/example/briefingapi/briefing/presentation/BriefingV2ApiTest.java
@@ -1,0 +1,38 @@
+package com.example.briefingapi.briefing.presentation;
+
+import com.example.briefingcommon.domain.repository.article.BriefingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BriefingV2ApiTest {
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+    @Autowired
+    private BriefingRepository briefingRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    @DisplayName("브리핑 상세 조회 기능 테스트입니다.")
+    void 브리핑_상세_조회() throws Exception {
+
+    }
+}

--- a/Briefing-Api/src/test/java/com/example/briefingapi/briefing/presentation/BriefingV2ApiTest.java
+++ b/Briefing-Api/src/test/java/com/example/briefingapi/briefing/presentation/BriefingV2ApiTest.java
@@ -1,6 +1,8 @@
 package com.example.briefingapi.briefing.presentation;
 
 import com.example.briefingcommon.domain.repository.article.BriefingRepository;
+import com.example.briefingcommon.entity.Briefing;
+import com.example.briefingcommon.entity.enums.BriefingType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,10 +11,19 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -31,8 +42,81 @@ class BriefingV2ApiTest {
     }
 
     @Test
-    @DisplayName("브리핑 상세 조회 기능 테스트입니다.")
-    void 브리핑_상세_조회() throws Exception {
+    @DisplayName("[BriefingV2Api] 상세 조회 - OK")
+    void 브리핑_상세_조회_OK() throws Exception {
+        // given
+        Briefing briefing =
+                Briefing.builder()
+                        .title("제목")
+                        .subtitle("부제목")
+                        .content("내용")
+                        .ranks(1)
+                        .type(BriefingType.SOCIAL)
+                        .build();
+        Briefing savedBriefing = briefingRepository.save(briefing);
+        Long briefingId = savedBriefing.getId();
 
+        // when & then
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v2/briefings/{id}", briefingId);
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.title").value("제목"))
+                .andExpect(jsonPath("$.result.id").value(briefingId));
+    }
+
+    @Test
+    @DisplayName("[BriefingV2Api] 상세 조회 - NOT FOUND")
+    void 브리핑_상세_조회_NOT_FOUND() throws Exception {
+        // given
+        Long briefingId = 0L;
+
+        // when & then
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v2/briefings/{id}", briefingId);
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    @DisplayName("[BriefingV2Api] 상세 조회 - 100명이 동시에 조회하면 100의 조회수가 늘어나야 합니다.")
+    void 브리핑_상세_조회_동시_요청() throws Exception {
+        // given
+        final int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        Briefing briefing =
+                Briefing.builder()
+                        .title("제목")
+                        .subtitle("부제목")
+                        .content("내용")
+                        .ranks(1)
+                        .type(BriefingType.SOCIAL)
+                        .build();
+        Briefing savedBriefing = briefingRepository.save(briefing);
+        Long briefingId = savedBriefing.getId();
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.execute(
+                    () -> {
+                        try {
+                            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get("/v2/briefings/{id}", briefingId);
+                            mockMvc.perform(requestBuilder);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                        finally {
+                            latch.countDown();
+                        }
+                    });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        Briefing updatedBriefing = briefingRepository.findById(briefingId).orElseThrow();
+        assertEquals(numberOfThreads, updatedBriefing.getViewCount());
     }
 }

--- a/core/Briefing-Common/src/main/generated/com/example/briefingcommon/entity/QBriefing.java
+++ b/core/Briefing-Common/src/main/generated/com/example/briefingcommon/entity/QBriefing.java
@@ -46,6 +46,8 @@ public class QBriefing extends EntityPathBase<Briefing> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
+    public final NumberPath<Integer> viewCount = createNumber("viewCount", Integer.class);
+
     public QBriefing(String variable) {
         super(Briefing.class, forVariable(variable));
     }

--- a/core/Briefing-Common/src/main/java/com/example/briefingcommon/domain/repository/article/BriefingRepository.java
+++ b/core/Briefing-Common/src/main/java/com/example/briefingcommon/domain/repository/article/BriefingRepository.java
@@ -9,6 +9,7 @@ import com.example.briefingcommon.entity.enums.BriefingType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +22,8 @@ public interface BriefingRepository
 
     @Query("SELECT b from Briefing b where b.ranks = 1 and b.type = :type order by b.createdAt desc")
     Page<Briefing> getBestTodayBriefing(@Param("type") BriefingType type, Pageable pageable);
+
+    @Modifying
+    @Query("update Briefing b set b.viewCount = b.viewCount + 1 where b.id = :id")
+    void updateViewCountById(Long id);
 }

--- a/core/Briefing-Common/src/main/java/com/example/briefingcommon/entity/Briefing.java
+++ b/core/Briefing-Common/src/main/java/com/example/briefingcommon/entity/Briefing.java
@@ -11,6 +11,7 @@ import jakarta.persistence.*;
 
 
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -52,6 +53,10 @@ public class Briefing extends BaseDateTimeEntity {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private GptModel gptModel = GptModel.GPT_3_5_TURBO;
+
+    @ColumnDefault("0")
+    @Builder.Default
+    private int viewCount = 0;
 
     public void setScrapCount(Integer scrapCount) {
         this.scrapCount = scrapCount;


### PR DESCRIPTION
# 🚀 개요
홈화면에서 스크랩 수를 노출하는 대신 조회수를 보여주기 위해
Briefing 테이블에 조회수를 누적합니다.

## ⏳ 작업 내용
-  Briefing 테이블 viewCount 추가
-  Briefing 상세조회 API Call 하나 당 조회수 1 증가
-  통합테스트 작성하기

### 📝 논의사항
H2 DB에 붙는 test 프로파일을 추가하고 API 통합 테스트를 작성했습니다.
아직 조회수 관련 기획이 없어서 우선 조회수 쌓기만 하고,
추후 기획이 확정되면 응답에 추가하면 될 것 같습니다.