### PR TITLE
Feature/177 : 애플로그인 사용자명 랜덤 세팅

### DIFF
--- a/Briefing-Api/src/main/java/com/example/briefingapi/member/business/MemberConverter.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/member/business/MemberConverter.java
@@ -37,12 +37,13 @@ public class MemberConverter {
                 .build();
     }
 
-    public static Member toMember(String appleSocialId) {
+    public static Member toMember(String appleSocialId, String nickName) {
         return Member.builder()
                 //                .profileImgUrl(googleUserInfo.getPicture())
                 //                .nickName(googleUserInfo.getName())
                 .socialId(appleSocialId)
                 .socialType(SocialType.APPLE)
+                .nickName(nickName)
                 .role(MemberRole.ROLE_USER)
                 .status(MemberStatus.ACTIVE)
                 .build();

--- a/Briefing-Api/src/main/java/com/example/briefingapi/member/implement/MemberCommandService.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/member/implement/MemberCommandService.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Optional;
 
 import com.example.briefingapi.member.business.MemberConverter;
-import com.example.briefingcommon.common.constant.BriefingStatic;
 import com.example.briefingcommon.domain.repository.FcmTokenRepository;
 import com.example.briefingcommon.domain.repository.member.MemberRepository;
 import com.example.briefingapi.member.presentation.dto.MemberRequest;
@@ -18,7 +17,7 @@ import com.example.briefingcommon.common.exception.common.ErrorCode;
 import com.example.briefingcommon.entity.FcmToken;
 import com.example.briefingcommon.entity.Member;
 import com.example.briefingcommon.entity.enums.SocialType;
-import com.example.briefinginfra.feign.nickname.hwanmoo.client.NickNameClient;
+import com.example.briefinginfra.feign.nickname.hwanmoo.adapter.NickNameGenerator;
 import com.example.briefinginfra.feign.oauth.apple.client.AppleOauth2Client;
 import com.example.briefinginfra.feign.oauth.apple.dto.ApplePublicKey;
 import com.example.briefinginfra.feign.oauth.apple.dto.ApplePublicKeyList;
@@ -34,15 +33,13 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 
-import static com.example.briefingcommon.common.constant.BriefingStatic.*;
-
 @Service
 @RequiredArgsConstructor
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final AppleOauth2Client appleOauth2Client;
-    private final NickNameClient nickNameClient;
+    private final NickNameGenerator nickNameGenerator;
 
     private final FcmTokenRepository fcmTokenRepository;
 
@@ -92,9 +89,7 @@ public class MemberCommandService {
         Optional<Member> foundMember =
                 memberRepository.findBySocialIdAndSocialType(appleSocialId, SocialType.APPLE);
 
-        String nickName = "";
-        List<String> nickNameWords = nickNameClient.getNickName(NICK_NAME_FORMAT, NICK_NAME_COUNT, NICK_NAME_MAX_LENGTH).getWords();
-        if(!nickNameWords.isEmpty()) nickName = nickNameWords.get(0);
+        String nickName = nickNameGenerator.getOneRandomNickName();
 
         return foundMember.isEmpty()
                 ? memberRepository.save(MemberConverter.toMember(appleSocialId, nickName))

--- a/Briefing-Api/src/main/java/com/example/briefingapi/member/implement/MemberCommandService.java
+++ b/Briefing-Api/src/main/java/com/example/briefingapi/member/implement/MemberCommandService.java
@@ -5,9 +5,11 @@ import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 
 import com.example.briefingapi.member.business.MemberConverter;
+import com.example.briefingcommon.common.constant.BriefingStatic;
 import com.example.briefingcommon.domain.repository.FcmTokenRepository;
 import com.example.briefingcommon.domain.repository.member.MemberRepository;
 import com.example.briefingapi.member.presentation.dto.MemberRequest;
@@ -16,10 +18,11 @@ import com.example.briefingcommon.common.exception.common.ErrorCode;
 import com.example.briefingcommon.entity.FcmToken;
 import com.example.briefingcommon.entity.Member;
 import com.example.briefingcommon.entity.enums.SocialType;
+import com.example.briefinginfra.feign.nickname.hwanmoo.client.NickNameClient;
 import com.example.briefinginfra.feign.oauth.apple.client.AppleOauth2Client;
 import com.example.briefinginfra.feign.oauth.apple.dto.ApplePublicKey;
 import com.example.briefinginfra.feign.oauth.apple.dto.ApplePublicKeyList;
-import com.example.briefinginfra.feign.oauth.google.client.GoogleOauth2Client;
+
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -27,10 +30,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
+
+import static com.example.briefingcommon.common.constant.BriefingStatic.*;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +42,7 @@ public class MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final AppleOauth2Client appleOauth2Client;
+    private final NickNameClient nickNameClient;
 
     private final FcmTokenRepository fcmTokenRepository;
 
@@ -87,8 +92,12 @@ public class MemberCommandService {
         Optional<Member> foundMember =
                 memberRepository.findBySocialIdAndSocialType(appleSocialId, SocialType.APPLE);
 
+        String nickName = "";
+        List<String> nickNameWords = nickNameClient.getNickName(NICK_NAME_FORMAT, NICK_NAME_COUNT, NICK_NAME_MAX_LENGTH).getWords();
+        if(!nickNameWords.isEmpty()) nickName = nickNameWords.get(0);
+
         return foundMember.isEmpty()
-                ? memberRepository.save(MemberConverter.toMember(appleSocialId))
+                ? memberRepository.save(MemberConverter.toMember(appleSocialId, nickName))
                 : foundMember.get();
     }
 

--- a/core/Briefing-Common/src/main/java/com/example/briefingcommon/common/constant/BriefingStatic.java
+++ b/core/Briefing-Common/src/main/java/com/example/briefingcommon/common/constant/BriefingStatic.java
@@ -1,0 +1,7 @@
+package com.example.briefingcommon.common.constant;
+
+public class BriefingStatic {
+    public static final String NICK_NAME_FORMAT = "json";
+    public static final int NICK_NAME_COUNT = 1;
+    public static final int NICK_NAME_MAX_LENGTH = 8;
+}

--- a/core/Briefing-Common/src/main/java/com/example/briefingcommon/common/constant/BriefingStatic.java
+++ b/core/Briefing-Common/src/main/java/com/example/briefingcommon/common/constant/BriefingStatic.java
@@ -4,4 +4,6 @@ public class BriefingStatic {
     public static final String NICK_NAME_FORMAT = "json";
     public static final int NICK_NAME_COUNT = 1;
     public static final int NICK_NAME_MAX_LENGTH = 8;
+
+    public static final String DEFAULT_NICK_NAME = "하품하는 프로도";
 }

--- a/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGenerator.java
+++ b/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGenerator.java
@@ -1,0 +1,51 @@
+package com.example.briefinginfra.feign.nickname.hwanmoo.adapter;
+
+import com.example.briefinginfra.feign.nickname.hwanmoo.client.NickNameClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.example.briefingcommon.common.constant.BriefingStatic.*;
+import static com.example.briefingcommon.common.constant.BriefingStatic.NICK_NAME_FORMAT;
+
+@Component
+@RequiredArgsConstructor
+public class NickNameGenerator {
+    private final NickNameClient nickNameClient;
+
+    /**
+     * 기본 최대 길이를 사용하여 랜덤 닉네임을 생성하고 반환합니다.
+     * 이 메소드는 내부적으로 {@code getOneRandomNickNameWithDetails}를 호출합니다.
+     *
+     * @return 생성된 닉네임. 닉네임 생성에 실패한 경우 빈 문자열을 반환합니다.
+     */
+    public String getOneRandomNickName() {
+        return getOneRandomNickNameWithDetails(NICK_NAME_MAX_LENGTH);
+    }
+
+    /**
+     * 사용자가 지정한 최대 길이를 사용하여 랜덤 닉네임을 생성하고 반환합니다.
+     * 이 메소드는 내부적으로 {@code getOneRandomNickNameWithDetails}를 호출합니다.
+     *
+     * @param maxLength 생성할 닉네임의 최대 길이
+     * @return 생성된 닉네임. 닉네임 생성에 실패한 경우 빈 문자열을 반환합니다.
+     */
+    public String getOneRandomNickName(int maxLength) {
+        return getOneRandomNickNameWithDetails(maxLength);
+    }
+
+    /**
+     * 지정된 최대 길이를 사용하여 랜덤 닉네임을 생성하고, 생성된 목록에서 첫 번째 닉네임을 반환합니다.
+     * 이 메소드는 내부적으로 {@code NickNameClient}를 사용하여 닉네임을 요청합니다.
+     *
+     * @param maxLength 생성할 닉네임의 최대 길이
+     * @return 생성된 닉네임 중 첫 번째 닉네임. 닉네임 생성에 실패한 경우 빈 문자열을 반환합니다.
+     */
+    private String getOneRandomNickNameWithDetails(int maxLength) {
+        List<String> nickNameWords = nickNameClient.getNickName(NICK_NAME_FORMAT, NICK_NAME_COUNT, maxLength).getWords();
+        if (!nickNameWords.isEmpty()) return nickNameWords.get(0);
+        return "";
+    }
+}
+

--- a/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGenerator.java
+++ b/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGenerator.java
@@ -45,7 +45,7 @@ public class NickNameGenerator {
     private String getOneRandomNickNameWithDetails(int maxLength) {
         List<String> nickNameWords = nickNameClient.getNickName(NICK_NAME_FORMAT, NICK_NAME_COUNT, maxLength).getWords();
         if (!nickNameWords.isEmpty()) return nickNameWords.get(0);
-        return "";
+        return DEFAULT_NICK_NAME;
     }
 }
 

--- a/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/client/NickNameClient.java
+++ b/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/client/NickNameClient.java
@@ -1,0 +1,17 @@
+package com.example.briefinginfra.feign.nickname.hwanmoo.client;
+
+import com.example.briefinginfra.feign.nickname.hwanmoo.dto.NickNameRes;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "nickNameClient",
+        url = "https://nickname.hwanmoo.kr"
+)
+@Component
+public interface NickNameClient {
+    @GetMapping(value = "/")
+    NickNameRes getNickName(@RequestParam(defaultValue = "json") String format, @RequestParam(defaultValue = "1") int count, @RequestParam(defaultValue = "8") int max_length);
+}

--- a/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/dto/NickNameRes.java
+++ b/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/dto/NickNameRes.java
@@ -1,0 +1,11 @@
+package com.example.briefinginfra.feign.nickname.hwanmoo.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class NickNameRes {
+    private List<String> words;
+    private String seed;
+}

--- a/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/dto/NickNameRes.java
+++ b/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/dto/NickNameRes.java
@@ -3,11 +3,12 @@ package com.example.briefinginfra.feign.nickname.hwanmoo.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 public class NickNameRes {
-    private List<String> words;
+    private List<String> words = new ArrayList<>();
     private String seed;
 }

--- a/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/dto/NickNameRes.java
+++ b/core/Briefing-Infra/src/main/java/com/example/briefinginfra/feign/nickname/hwanmoo/dto/NickNameRes.java
@@ -1,10 +1,12 @@
 package com.example.briefinginfra.feign.nickname.hwanmoo.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 public class NickNameRes {
     private List<String> words;
     private String seed;

--- a/core/Briefing-Infra/src/test/java/com/example/briefinginfra/config/TestConfig.java
+++ b/core/Briefing-Infra/src/test/java/com/example/briefinginfra/config/TestConfig.java
@@ -1,0 +1,20 @@
+package com.example.briefinginfra.config;
+
+import com.example.briefinginfra.feign.nickname.hwanmoo.adapter.NickNameGenerator;
+import com.example.briefinginfra.feign.nickname.hwanmoo.client.NickNameClient;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+    @Bean
+    public NickNameClient nickNameClient() {
+        return Mockito.mock(NickNameClient.class);
+    }
+
+    @Bean
+    public NickNameGenerator nickNameGenerator(NickNameClient nickNameClient) {
+        return new NickNameGenerator(nickNameClient);
+    }
+}

--- a/core/Briefing-Infra/src/test/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGeneratorTest.java
+++ b/core/Briefing-Infra/src/test/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.example.briefinginfra.feign.nickname.hwanmoo.adapter;
 
+import com.example.briefingcommon.common.constant.BriefingStatic;
 import com.example.briefinginfra.config.TestConfig;
 import com.example.briefinginfra.feign.nickname.hwanmoo.client.NickNameClient;
 import com.example.briefinginfra.feign.nickname.hwanmoo.dto.NickNameRes;
@@ -13,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,4 +44,20 @@ class NickNameGeneratorTest {
         assertThat(nickName).isNotNull();
         assertThat(nickName).isEqualTo("하품하는 프로도");
     }
+
+    @Test
+    @DisplayName("[NickNameGenerator] 랜덤 닉네임 생성 - 빈 리스트 (기본 닉네임)")
+    void 랜덤_닉네임_생성_기본_닉네임() throws Exception {
+        // given
+        NickNameRes mockResponse = new NickNameRes();
+        when(nickNameClient.getNickName("json", 1, 8)).thenReturn(mockResponse);
+
+        // when
+        String nickName = nickNameGenerator.getOneRandomNickName();
+
+        // then
+        assertThat(nickName).isNotNull();
+        assertThat(nickName).isEqualTo(BriefingStatic.DEFAULT_NICK_NAME);
+    }
+
 }

--- a/core/Briefing-Infra/src/test/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGeneratorTest.java
+++ b/core/Briefing-Infra/src/test/java/com/example/briefinginfra/feign/nickname/hwanmoo/adapter/NickNameGeneratorTest.java
@@ -1,0 +1,45 @@
+package com.example.briefinginfra.feign.nickname.hwanmoo.adapter;
+
+import com.example.briefinginfra.config.TestConfig;
+import com.example.briefinginfra.feign.nickname.hwanmoo.client.NickNameClient;
+import com.example.briefinginfra.feign.nickname.hwanmoo.dto.NickNameRes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class) // 테스트 설정 클래스 지정
+class NickNameGeneratorTest {
+    @Autowired
+    private NickNameGenerator nickNameGenerator;
+
+    @MockBean
+    private NickNameClient nickNameClient;
+
+    @Test
+    @DisplayName("[NickNameGenerator] 랜덤 닉네임 생성")
+    void 랜덤_닉네임_생성() throws Exception {
+        // given
+        NickNameRes mockResponse = new NickNameRes();
+        mockResponse.setWords(Arrays.asList("하품하는 프로도"));
+        when(nickNameClient.getNickName("json", 1, 8)).thenReturn(mockResponse);
+
+        // when
+        String nickName = nickNameGenerator.getOneRandomNickName();
+
+        // then
+        assertThat(nickName).isNotNull();
+        assertThat(nickName).isEqualTo("하품하는 프로도");
+    }
+}


### PR DESCRIPTION
# 🚀 개요
애플로그인 시, 사용자명을 받을 수 없어 외부 API를 사용해 랜덤 사용자명을 세팅해줍니다.

## ⏳ 작업 내용
- [x] 애플로그인 사용자명 랜덤 세팅 로직 추가
- [x] 클라이언트 코드에서 NickNameClient(FeignClient)를 직접 의존하게 되면, 클라이언트 코드에서 응답 형식, 닉네임 생성 등의 관심사를 가지게 돼서 해당 관심사들을 adapter(NickNameGenerator)에 포함하여 제공하도록 설계
- [x] NickNameGenerator 단위 테스트 작성 (NickNameClient는 mocking하여 의존성 격리)

### 📝 논의사항


